### PR TITLE
feat: separação de responsabilidades de placement_scene e battle_scene

### DIFF
--- a/cmd/battleship/main.go
+++ b/cmd/battleship/main.go
@@ -5,18 +5,21 @@ import (
 
 	"github.com/allanjose001/go-battleship/game"
 	"github.com/allanjose001/go-battleship/game/components"
+	"github.com/allanjose001/go-battleship/internal/bootstrap"
 	"github.com/allanjose001/go-battleship/internal/service"
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func main() {
+	bootstrap.InitRandom()
+
 	// 1. Setup de dados do Perfil
 	profile := &service.Profile{
 		Username:     "malub",
 		GamesPlayed:  10,
-		MedalsEarned: 4, 
+		MedalsEarned: 4,
 	}
-	
+
 	_ = service.SaveProfile(*profile)
 
 	// 2. Recursos Visuais
@@ -26,24 +29,16 @@ func main() {
 	g := game.NewGame()
 
 	// 4. Configuração de Janela e Resolução Lógica
-	ebiten.SetWindowSize(1280, 720) 
-	
+	ebiten.SetWindowSize(1280, 720)
+
 	// SetWindowTitle ajuda a identificar a tela de teste
 	ebiten.SetWindowTitle("Batalha Naval - Profile Scene Debug")
-	
+
 	// Habilitar redimensionamento sem quebrar o layout (usa o Layout() do game.go)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 
-<<<<<<< develop
-	err := ebiten.RunGame(g)
-	if err != nil {
-		panic(err)
-	}
-}
-=======
-	// 5. Execução do Loop principal
+	// 5. Execucao do Loop principal
 	if err := ebiten.RunGame(g); err != nil {
 		log.Fatal(err)
 	}
 }
->>>>>>> develop

--- a/game/components/ship.go
+++ b/game/components/ship.go
@@ -1,0 +1,116 @@
+// Package components contém widgets e helpers visuais reutilizáveis do jogo.
+package components
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/allanjose001/go-battleship/game/components/basic/colors"
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/game/shared/placement"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// DrawShip desenha um navio em três estados possíveis:
+// - colocado no tabuleiro
+// - sendo arrastado
+// - parado na lista de seleção à direita
+func DrawShip(screen *ebiten.Image, b *board.Board, ship *placement.ShipPlacement, active bool, orientation board.Orientation) {
+	// Se o navio ou a imagem não existem, não há nada para desenhar.
+	if ship == nil || ship.Image == nil {
+		return
+	}
+
+	// Options de desenho usadas para escalar, rotacionar e transladar a imagem.
+	op := &ebiten.DrawImageOptions{}
+
+	// Caso 1: navio já está colocado no tabuleiro.
+	if ship.Placed {
+		// Cada célula do tabuleiro tem o mesmo tamanho em pixels.
+		cellSize := b.Size / float64(board.Cols)
+
+		// Converte posição em células (X,Y) para coordenadas de tela.
+		x := b.X + float64(ship.X)*cellSize
+		y := b.Y + float64(ship.Y)*cellSize
+
+		// Pega largura/altura originais da imagem.
+		iw, ih := ship.Image.Size()
+
+		// Escala a imagem para ocupar o número de células do navio.
+		op.GeoM.Scale(
+			(cellSize*float64(ship.Size))/float64(iw),
+			cellSize/float64(ih),
+		)
+
+		// Se o navio está vertical, rotaciona 90° e ajusta a origem.
+		if ship.Orientation == board.Vertical {
+			op.GeoM.Rotate(math.Pi / 2)
+			op.GeoM.Translate(cellSize, 0)
+		}
+
+		// Move a imagem escalada para a posição calculada no tabuleiro.
+		op.GeoM.Translate(x, y)
+
+		// Se este navio é o ativo, desenha um retângulo de destaque em volta.
+		if active {
+			highlightColor := color.RGBA{255, 255, 0, 160}
+			highlightW := cellSize * float64(ship.Size)
+			highlightH := cellSize
+			if ship.Orientation == board.Vertical {
+				highlightW, highlightH = highlightH, highlightW
+			}
+			ebitenutil.DrawRect(screen, x-2, y-2, highlightW+4, highlightH+4, highlightColor)
+		}
+
+		// Finalmente desenha a imagem do navio.
+		screen.DrawImage(ship.Image, op)
+		return
+	}
+
+	// Caso 2: navio está sendo arrastado pelo jogador.
+	if ship.Dragging {
+		// Usa o mesmo tamanho de célula do tabuleiro para manter escala consistente.
+		cellSize := b.Size / float64(board.Cols)
+		iw, ih := ship.Image.Size()
+
+		// Escala imagem proporcional ao tamanho do navio.
+		op.GeoM.Scale(
+			(cellSize*float64(ship.Size))/float64(iw),
+			cellSize/float64(ih),
+		)
+
+		// Para navio sendo arrastado, usamos a orientação "corrente" do service.
+		if orientation == board.Vertical {
+			op.GeoM.Rotate(math.Pi / 2)
+			op.GeoM.Translate(cellSize, 0)
+		}
+
+		// Posiciona a imagem na posição de drag (em pixels).
+		op.GeoM.Translate(ship.DragX, ship.DragY)
+
+		// Se está ativo, desenha highlight em volta da posição de drag.
+		if active {
+			highlightColor := color.RGBA{255, 255, 0, 160}
+			highlightW := cellSize * float64(ship.Size)
+			highlightH := cellSize
+			if orientation == board.Vertical {
+				highlightW, highlightH = highlightH, highlightW
+			}
+			ebitenutil.DrawRect(screen, ship.DragX-2, ship.DragY-2, highlightW+4, highlightH+4, highlightColor)
+		}
+	} else {
+		// Caso 3: navio está parado na lista lateral (ainda não selecionado).
+		// Apenas translada a imagem para a posição fixa da lista.
+		op.GeoM.Translate(ship.ListX, ship.ListY)
+
+		// Se é o navio ativo na lista, desenha uma borda branca em volta.
+		if active {
+			w, h := ship.Image.Size()
+			highlightColor := colors.White
+			ebitenutil.DrawRect(screen, ship.ListX-2, ship.ListY-2, float64(w)+4, float64(h)+4, highlightColor)
+		}
+	}
+	// Em qualquer um dos casos acima, desenha a imagem do navio com as transformações calculadas.
+	screen.DrawImage(ship.Image, op)
+}

--- a/game/game.go
+++ b/game/game.go
@@ -25,6 +25,10 @@ func NewGame() *Game {
 		stack: scenes.NewSceneStack(windowSize, &scenes.HomeScreen{}), //incializa com primeira scene
 	}
 
+	scenes.SwitchTo = func(next scenes.Scene) {
+		g.stack.Replace(next)
+	}
+
 	return g
 
 	// 1. Inicializa o estado global do jogo (onde ficam os dados de tabuleiros, etc)

--- a/game/scenes/placement_scene.go
+++ b/game/scenes/placement_scene.go
@@ -2,57 +2,81 @@ package scenes
 
 import (
 	"image/color"
-	"math"
-	"math/rand"
-	"time"
 
 	"github.com/allanjose001/go-battleship/game/components"
 	"github.com/allanjose001/go-battleship/game/components/basic"
 	"github.com/allanjose001/go-battleship/game/components/basic/colors"
 	"github.com/allanjose001/go-battleship/game/shared/board"
 	"github.com/allanjose001/go-battleship/game/shared/placement"
-	"github.com/allanjose001/go-battleship/game/shared/setup"
-	"github.com/allanjose001/go-battleship/game/state"
+	"github.com/allanjose001/go-battleship/internal/service"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
+// placementRenderer é responsável por desenhar o tabuleiro de posicionamento
+// e todos os navios do jogador, delegando o desenho de cada navio
+// para o componente DrawShip.
+type placementRenderer struct {
+	screen *ebiten.Image
+}
+
+// Draw desenha o tabuleiro e percorre a lista de navios,
+// indicando qual deles está ativo para ser destacado.
+func (r *placementRenderer) Draw(b *board.Board, ships []*placement.ShipPlacement, active *placement.ShipPlacement, orientation board.Orientation) {
+	b.Draw(r.screen)
+	for _, ship := range ships {
+		components.DrawShip(r.screen, b, ship, active == ship, orientation)
+	}
+}
+
+// PlacementScene controla a tela onde o jogador posiciona seus navios
+// antes de iniciar a batalha. Ela orquestra a interação com o serviço
+// de placement e os componentes de interface.
 type PlacementScene struct {
-	board        *board.Board
-	ships        []*placement.ShipPlacement
-	selectedShip *placement.ShipPlacement
-	activeShip   *placement.ShipPlacement // navio ativo para rotação
-	orientation  board.Orientation
-	actionsRow   *components.Row
-	playRow      *components.Row
-	playerLabel  *components.Text
-	playButton   *components.Button
+	// svc encapsula toda a regra de negócio de posicionamento
+	svc service.PlacementService
+	// board e ships são usados para construir o GameState de batalha
+	board *board.Board
+	ships []*placement.ShipPlacement
+	// container com a linha de botões sob o tabuleiro (Aleatório, Rotacionar)
+	leftButtons components.Widget
+	// playerLabel mostra o texto "Jogador 1" alinhado ao tabuleiro
+	playerLabel *components.Text
+	// playButton é o botão que dispara a transição para a batalha
+	playButton *components.Button
+	// container com a linha de start sob a coluna de navios
+	rightButtons components.Widget
 	StackHandler
 }
 
+// NewPlacementScene cria uma cena de posicionamento vazia.
+// A configuração completa é feita em OnEnter.
 func NewPlacementScene() *PlacementScene {
 	return &PlacementScene{}
 }
 
-/* =======================
-   Interface Scene
-======================= */
-
+// OnEnter é chamado quando a cena entra em foco.
+// Aqui criamos o tabuleiro, carregamos imagens, configuramos navios,
+// serviços e os botões de interface.
 func (s *PlacementScene) OnEnter(prev Scene, size basic.Size) {
-	s.board = board.NewBoard(80, 100, 400)
+	// Cria o tabuleiro do jogador na tela
+	b := board.NewBoard(80, 100, 400)
+
+	// Tenta carregar a imagem de fundo do tabuleiro
 	bg, _, err := ebitenutil.NewImageFromFile("assets/images/Mask group.png")
 	if err == nil {
-		s.board.BackgroundImage = bg
+		b.BackgroundImage = bg
 	}
-	s.orientation = board.Horizontal
 
+	// Carrega os sprites dos navios com tamanhos diferentes
 	img1, _, _ := ebitenutil.NewImageFromFile("assets/images/1 slot 1.png")
 	img2, _, _ := ebitenutil.NewImageFromFile("assets/images/3 slots 2.png")
 	img3, _, _ := ebitenutil.NewImageFromFile("assets/images/Frame 400.png")
 	img4, _, _ := ebitenutil.NewImageFromFile("assets/images/NAVIO 4 SLOTS 1.png")
 
-	s.ships = []*placement.ShipPlacement{
+	// Cria a lista de navios disponíveis na lateral direita
+	ships := []*placement.ShipPlacement{
 		{Image: img3, Size: 6, ListX: 800, ListY: 100},
 		{Image: img4, Size: 4, ListX: 800, ListY: 180},
 		{Image: img2, Size: 3, ListX: 800, ListY: 240},
@@ -60,14 +84,41 @@ func (s *PlacementScene) OnEnter(prev Scene, size basic.Size) {
 		{Image: img1, Size: 1, ListX: 800, ListY: 360},
 	}
 
+	s.board = b
+	s.ships = ships
+
+	// Cria o serviço de placement, responsável apenas por posicionamento visual
+	s.svc = service.NewPlacementService(b, ships)
+
+	// Cores dos botões
 	btnColor := color.RGBA{48, 67, 103, 255}
 	playBtnColor := color.RGBA{60, 120, 60, 255}
 
-	s.actionsRow = components.NewRow(
-		basic.Point{X: 80, Y: 580},
-		100,
-		basic.Size{W: 400, H: 50},
-		basic.Start,
+	// Botão para iniciar a batalha. Só funciona se todos os navios
+	// tiverem sido posicionados no tabuleiro.
+	s.playButton = components.NewButton(
+		basic.Point{},
+		basic.Size{W: 150, H: 50},
+		"Partida",
+		playBtnColor,
+		colors.White,
+		func(b *components.Button) {
+			if !s.svc.AllShipsPlaced() {
+				return
+			}
+
+			factory := service.NewGameService()
+			gs := factory.NewBattleGameState(s.board, s.ships)
+			SwitchTo(NewBattleScene(gs))
+		},
+	)
+
+	x, y, sizeX := s.svc.BoardRect()
+	leftRow := components.NewRow(
+		basic.Point{}, // pos relativo ao container
+		50,
+		basic.Size{W: float32(sizeX), H: 50},
+		basic.Center,
 		basic.Center,
 		[]components.Widget{
 			components.NewButton(
@@ -76,7 +127,9 @@ func (s *PlacementScene) OnEnter(prev Scene, size basic.Size) {
 				"Aleatório",
 				btnColor,
 				colors.White,
-				func(b *components.Button) { s.randomPlacement() },
+				func(b *components.Button) {
+					s.svc.RandomPlacement()
+				},
 			),
 			components.NewButton(
 				basic.Point{},
@@ -85,70 +138,47 @@ func (s *PlacementScene) OnEnter(prev Scene, size basic.Size) {
 				btnColor,
 				colors.White,
 				func(b *components.Button) {
-					// Determina a nova orientação baseada no navio ativo ou na global
-					targetOri := board.Horizontal
-
-					if s.activeShip != nil && s.activeShip.Placed {
-						// Se tem navio no board, alterna a partir da orientação DELE
-						if s.activeShip.Orientation == board.Horizontal {
-							targetOri = board.Vertical
-						} else {
-							targetOri = board.Horizontal
-						}
-
-						// Tenta rotacionar o navio
-						s.rotateShipTo(s.activeShip, targetOri)
-						// Sincroniza a orientação global com o resultado (se rotacionou ou não)
-						s.orientation = s.activeShip.Orientation
-					} else {
-						// Se não tem navio ativo, apenas alterna a orientação global para o próximo arraste
-						if s.orientation == board.Horizontal {
-							s.orientation = board.Vertical
-						} else {
-							s.orientation = board.Horizontal
-						}
-					}
+					s.svc.Rotate()
 				},
 			),
 		},
 	)
-
-	s.playButton = components.NewButton(
-		basic.Point{},
-		basic.Size{W: 150, H: 50},
-		"JOGAR",
-		playBtnColor,
-		colors.White,
-		func(b *components.Button) {
-			if s.AllShipsPlaced() {
-				gs := state.NewGameState()
-				gs.PlayerBoard = s.board
-				gs.PlayerShips = s.ships
-
-				// Ajusta o tabuleiro da IA para ser simétrico ao do jogador
-				gs.AIBoard.X = 1280 - s.board.X - s.board.Size // 1280 - 80 - 400 = 800
-				gs.AIBoard.Y = s.board.Y
-				gs.AIBoard.Size = s.board.Size
-
-				// Adicionamos navios aleatórios para a IA
-				setup.RandomlyPlaceAIShips(gs.AIBoard)
-
-				SwitchTo(NewBattleScene(gs))
-			}
-		},
+	s.leftButtons = components.NewContainer(
+		basic.Point{X: float32(x), Y: float32(y + sizeX + 80)},
+		basic.Size{W: float32(sizeX), H: 50},
+		25,
+		nil,
+		basic.Center,
+		basic.Center,
+		leftRow,
 	)
-
-	s.playRow = components.NewRow(
-		basic.Point{X: 800, Y: 580},
+	minListX := ships[0].ListX
+	for _, sp := range ships {
+		if sp.ListX < minListX {
+			minListX = sp.ListX
+		}
+	}
+	rightRow := components.NewRow(
+		basic.Point{},
 		0,
-		basic.Size{W: 400, H: 50},
+		basic.Size{W: 200, H: 50},
 		basic.Center,
 		basic.Center,
 		[]components.Widget{
 			s.playButton,
 		},
 	)
+	s.rightButtons = components.NewContainer(
+		basic.Point{X: float32(minListX), Y: float32(y + sizeX + 80)},
+		basic.Size{W: 200, H: 50},
+		25,
+		nil,
+		basic.Center,
+		basic.Center,
+		rightRow,
+	)
 
+	// Cria o rótulo com o nome do jogador
 	s.playerLabel = components.NewText(
 		basic.Point{X: 250, Y: 520},
 		"Jogador 1",
@@ -157,320 +187,77 @@ func (s *PlacementScene) OnEnter(prev Scene, size basic.Size) {
 	)
 	// Centraliza o texto em relação ao tabuleiro
 	textW := s.playerLabel.GetSize().W
-	boardCenter := s.board.X + s.board.Size/2
+	boardCenter := x + sizeX/2
 	newX := boardCenter - float64(textW)/2
 	s.playerLabel.SetPos(basic.Point{X: float32(newX), Y: 520})
 }
 
+// OnExit é chamado ao sair da cena de placement.
+// Não há limpeza especial necessária neste caso.
 func (s *PlacementScene) OnExit(next Scene) {}
 
-/* =======================
-   Update
-======================= */
-
+// Update é chamado a cada frame para tratar entradas do usuário.
+// Aqui atualizamos botões, rótulo e delegamos para o serviço de placement
+// as interações de clique/arraste dos navios.
 func (s *PlacementScene) Update() error {
-	s.actionsRow.Update(basic.Point{})
-	s.playRow.Update(basic.Point{})
+	if s.leftButtons != nil {
+		s.leftButtons.Update(basic.Point{})
+	}
+	if s.rightButtons != nil {
+		s.rightButtons.Update(basic.Point{})
+	}
 	s.playerLabel.Update(basic.Point{})
 
-	// Habilita o botão JOGAR apenas se todos os barcos estiverem posicionados
-
-	if s.AllShipsPlaced() {
-		s.playButton.ToggleDisabled()
-
-	}
-
+	// Pega a posição atual do mouse em coordenadas de tela
 	mx, my := ebiten.CursorPosition()
 	mouseX, mouseY := float64(mx), float64(my)
 
-	//Clique para pegar navio (lista ou tabuleiro)
+	// Clique do mouse: tenta selecionar um navio no tabuleiro
+	// ou na lista da lateral direita.
 	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 
-		//Primeiro: tentar pegar navio do tabuleiro
-		for _, ship := range s.ships {
-			if !ship.Placed {
-				continue
-			}
-
-			cellSize := s.board.Size / float64(board.Cols)
-			x := s.board.X + float64(ship.X)*cellSize
-			y := s.board.Y + float64(ship.Y)*cellSize
-
-			w := cellSize * float64(ship.Size)
-			h := cellSize
-			if ship.Orientation == board.Vertical {
-				w, h = h, w
-			}
-
-			if mouseX >= x && mouseX <= x+w && mouseY >= y && mouseY <= y+h {
-				s.removeShipFromBoard(ship)
-
-				ship.Dragging = true
-				ship.DragX = x
-				ship.DragY = y
-				ship.OffsetX = mouseX - x
-				ship.OffsetY = mouseY - y
-
-				s.selectedShip = ship
-				s.activeShip = ship
-				s.orientation = ship.Orientation //Sincroniza a orientação global com a do navio
-				return nil
-			}
+		if s.svc.SelectOnBoard(mouseX, mouseY) {
+			return nil
 		}
 
-		//Depois: tentar pegar da lista
-		for _, ship := range s.ships {
-			if ship.Placed {
-				continue
-			}
-
-			w, h := ship.Image.Size()
-			// Consideramos o tamanho visual na lista (sem rotação por enquanto na lista)
-			if mouseX >= ship.ListX && mouseX <= ship.ListX+float64(w) &&
-				mouseY >= ship.ListY && mouseY <= ship.ListY+float64(h) {
-
-				ship.Dragging = true
-				ship.DragX = ship.ListX
-				ship.DragY = ship.ListY
-				ship.OffsetX = mouseX - ship.ListX
-				ship.OffsetY = mouseY - ship.ListY
-				s.selectedShip = ship
-				s.activeShip = ship //tornar ativo ao pegar da lista
-				return nil
-			}
+		if s.svc.SelectOnList(mouseX, mouseY) {
+			return nil
 		}
 	}
 
-	//Arrastando
-	if s.selectedShip != nil && s.selectedShip.Dragging {
-		s.selectedShip.DragX = mouseX - s.selectedShip.OffsetX
-		s.selectedShip.DragY = mouseY - s.selectedShip.OffsetY
-	}
+	// Atualiza posição do navio que está sendo arrastado
+	s.svc.UpdateDragging(mouseX, mouseY)
 
-	//Soltar
-	if inpututil.IsMouseButtonJustReleased(ebiten.MouseButtonLeft) && s.selectedShip != nil {
-		s.tryPlaceSelectedShip(mouseX, mouseY)
-		s.selectedShip = nil
+	// Ao soltar o botão do mouse, tenta soltar o navio no tabuleiro
+	if inpututil.IsMouseButtonJustReleased(ebiten.MouseButtonLeft) {
+		s.svc.DropSelected()
 	}
 
 	return nil
 }
 
-/* =======================
-   Draw
-======================= */
-
+// Draw é responsável por desenhar todo o conteúdo da cena:
+// tabuleiro, navios, botões, rótulo do jogador e a linha divisória.
 func (s *PlacementScene) Draw(screen *ebiten.Image) {
-	s.board.Draw(screen)
+	// Renderer que sabe como desenhar tabuleiro e navios
+	r := &placementRenderer{screen: screen}
+	s.svc.Draw(r)
 
-	for _, ship := range s.ships {
-		op := &ebiten.DrawImageOptions{}
-
-		if ship.Placed {
-			cellSize := s.board.Size / float64(board.Cols)
-			x := s.board.X + float64(ship.X)*cellSize
-			y := s.board.Y + float64(ship.Y)*cellSize
-
-			iw, ih := ship.Image.Size()
-			op.GeoM.Scale(
-				(cellSize*float64(ship.Size))/float64(iw),
-				cellSize/float64(ih),
-			)
-
-			if ship.Orientation == board.Vertical {
-				op.GeoM.Rotate(math.Pi / 2)
-				op.GeoM.Translate(cellSize, 0)
-			}
-
-			op.GeoM.Translate(x, y)
-
-			// Destaque visual para o navio ativo (no tabuleiro)
-			if s.activeShip == ship {
-				var highlightColor color.RGBA = color.RGBA{255, 255, 0, 160} // Amarelo mais visível
-				highlightW := cellSize * float64(ship.Size)
-				highlightH := cellSize
-				if ship.Orientation == board.Vertical {
-					highlightW, highlightH = highlightH, highlightW
-				}
-				ebitenutil.DrawRect(screen, x-2, y-2, highlightW+4, highlightH+4, highlightColor)
-			}
-
-			screen.DrawImage(ship.Image, op)
-			continue
-		}
-
-		if ship.Dragging {
-			cellSize := s.board.Size / float64(board.Cols)
-			iw, ih := ship.Image.Size()
-
-			op.GeoM.Scale(
-				(cellSize*float64(ship.Size))/float64(iw),
-				cellSize/float64(ih),
-			)
-
-			if s.orientation == board.Vertical {
-				op.GeoM.Rotate(math.Pi / 2)
-				op.GeoM.Translate(cellSize, 0)
-			}
-
-			op.GeoM.Translate(ship.DragX, ship.DragY)
-
-			// 🔥 Destaque visual para o navio ativo (enquanto arrasta)
-			if s.activeShip == ship {
-				var highlightColor color.RGBA = color.RGBA{255, 255, 0, 160}
-				highlightW := cellSize * float64(ship.Size)
-				highlightH := cellSize
-				if s.orientation == board.Vertical {
-					highlightW, highlightH = highlightH, highlightW
-				}
-				ebitenutil.DrawRect(screen, ship.DragX-2, ship.DragY-2, highlightW+4, highlightH+4, highlightColor)
-			}
-		} else {
-			op.GeoM.Translate(ship.ListX, ship.ListY)
-
-			//  Destaque visual para o navio ativo (na lista)
-			if s.activeShip == ship {
-				w, h := ship.Image.Size()
-				var highlightColor color.RGBA = color.RGBA{255, 255, 0, 100}
-				ebitenutil.DrawRect(screen, ship.ListX-2, ship.ListY-2, float64(w)+4, float64(h)+4, highlightColor)
-			}
-		}
-
-		screen.DrawImage(ship.Image, op)
+	if s.leftButtons != nil {
+		s.leftButtons.Draw(screen)
 	}
-
-	s.actionsRow.Draw(screen)
-	s.playRow.Draw(screen)
+	if s.rightButtons != nil {
+		s.rightButtons.Draw(screen)
+	}
 	s.playerLabel.Draw(screen)
 
-	// Linha vertical separando tabuleiro e navios
+	// Linha vertical separando tabuleiro e navios da lateral
 	lineX := 640.0
-	lineY1 := s.board.Y
-	lineY2 := float64(s.actionsRow.GetPos().Y) + float64(s.actionsRow.GetSize().H)
+	_, y, sizeY := s.svc.BoardRect()
+	lineY1 := y
+	lineY2 := y + sizeY
 	ebitenutil.DrawLine(screen, lineX, lineY1, lineX, lineY2, colors.White)
 }
 
-/* =======================
-   Helpers
-======================= */
-
-func (s *PlacementScene) tryPlaceSelectedShip(mouseX, mouseY float64) {
-	ship := s.selectedShip
-	ship.Dragging = false
-
-	cellSize := s.board.Size / float64(board.Cols)
-
-	// Calcula a posição pretendida do topo-esquerdo do navio no tabuleiro
-	// baseada na posição atual de arraste
-	targetX := ship.DragX
-	targetY := ship.DragY
-
-	// Se estiver perto o suficiente do tabuleiro, tenta encaixar
-	if targetX+cellSize*float64(ship.Size) > s.board.X && targetX < s.board.X+s.board.Size &&
-		targetY+cellSize*float64(ship.Size) > s.board.Y && targetY < s.board.Y+s.board.Size {
-
-		col := int(math.Round((targetX - s.board.X) / cellSize))
-		row := int(math.Round((targetY - s.board.Y) / cellSize))
-
-		if s.board.CanPlace(ship.Size, row, col, s.orientation) {
-			s.board.PlaceShip(ship.Size, row, col, s.orientation)
-			ship.Placed = true
-			ship.X = col
-			ship.Y = row
-			ship.Orientation = s.orientation
-			s.activeShip = ship
-			return
-		}
-	}
-
-	//Drop inválido ou fora do tabuleiro -> volta pra lista
-	ship.Placed = false
-	s.activeShip = ship // Mesmo na lista, ele pode ser o ativo para rotacionar antes de puxar
-}
-
-func (s *PlacementScene) removeShipFromBoard(target *placement.ShipPlacement) {
-	target.Placed = false
-	s.board.Clear()
-
-	for _, ship := range s.ships {
-		if ship != target && ship.Placed {
-			s.board.PlaceShip(ship.Size, ship.Y, ship.X, ship.Orientation)
-		}
-	}
-}
-
-func (s *PlacementScene) randomPlacement() {
-	s.board.Clear()
-	rand.Seed(time.Now().UnixNano())
-
-	for _, ship := range s.ships {
-		ship.Placed = false
-	}
-
-	for _, ship := range s.ships {
-		for {
-			row := rand.Intn(board.Rows)
-			col := rand.Intn(board.Cols)
-			or := board.Orientation(rand.Intn(2))
-
-			if s.board.CanPlace(ship.Size, row, col, or) {
-				s.board.PlaceShip(ship.Size, row, col, or)
-				ship.Placed = true
-				ship.X = col
-				ship.Y = row
-				ship.Orientation = or
-				s.activeShip = ship //último navio colocado vira ativo
-				break
-			}
-		}
-	}
-}
-
-func (s *PlacementScene) findLastPlacedShip() {
-	// Procura o último navio colocado (mais recente)
-	for i := len(s.ships) - 1; i >= 0; i-- {
-		if s.ships[i].Placed {
-			s.activeShip = s.ships[i]
-			return
-		}
-	}
-	s.activeShip = nil
-}
-
-func (s *PlacementScene) rotateShipTo(ship *placement.ShipPlacement, newOri board.Orientation) {
-	if ship == nil || !ship.Placed {
-		return
-	}
-
-	// Se já estiver na orientação certa, não faz nada
-	if ship.Orientation == newOri {
-		return
-	}
-
-	s.removeShipFromBoard(ship)
-
-	if s.board.CanPlace(ship.Size, ship.Y, ship.X, newOri) {
-		s.board.PlaceShip(ship.Size, ship.Y, ship.X, newOri)
-		ship.Orientation = newOri
-		ship.Placed = true
-	} else {
-		// Se não couber, volta para a orientação original
-		s.board.PlaceShip(ship.Size, ship.Y, ship.X, ship.Orientation)
-		ship.Placed = true
-
-		// Opcional: Se não coube na orientação global,
-		// talvez devêssemos reverter a s.orientation global?
-		// Por enquanto deixamos assim para o usuário saber que ele tentou mudar.
-	}
-}
-
-func (s *PlacementScene) AllShipsPlaced() bool {
-	for _, ship := range s.ships {
-		if !ship.Placed {
-			return false
-		}
-	}
-	return true
-}
-
+// Verifica em tempo de compilação se PlacementScene implementa Scene.
 var _ Scene = (*PlacementScene)(nil)

--- a/game/shared/setup/ai_ship_setup.go
+++ b/game/shared/setup/ai_ship_setup.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/allanjose001/go-battleship/game/shared/board"
 )
@@ -11,7 +10,6 @@ import (
 // Útil para configurar o tabuleiro da IA.
 func RandomlyPlaceAIShips(b *board.Board) {
 	b.Clear()
-	rand.Seed(time.Now().UnixNano())
 
 	shipSizes := []int{6, 4, 3, 3, 1} // Mesmos tamanhos do jogador
 

--- a/internal/assets/loader.go
+++ b/internal/assets/loader.go
@@ -1,0 +1,66 @@
+// Asset Loader: utilitários de carregamento de imagens e animações
+// para a fase de batalha. Mantém o acesso aos arquivos centralizado
+// e converte formatos (como GIF) em ebiten.Image utilizável.
+package assets
+
+import (
+	"image/gif"
+	"os"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+const (
+	firePath = "assets/images/Fire.gif"
+	missPath = "assets/images/Ponto que já foi atingido 1.png"
+)
+
+// LoadFireAnimation:
+// - Abre o GIF
+// - Decodifica todos os frames e seus delays
+// - Converte imagens em ebiten.Image para desenhar animado
+func LoadFireAnimation() ([]*ebiten.Image, []int, error) {
+	f, err := os.Open(firePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	g, err := gif.DecodeAll(f)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	frames := make([]*ebiten.Image, len(g.Image))
+	delays := make([]int, len(g.Delay))
+
+	for i, img := range g.Image {
+		frames[i] = ebiten.NewImageFromImage(img)
+		delays[i] = g.Delay[i]
+	}
+
+	return frames, delays, nil
+}
+
+// LoadHitImage:
+// - Carrega uma imagem usada como efeito de acerto
+// - Caso a animação esteja indisponível, ela pode servir como fallback
+func LoadHitImage() (*ebiten.Image, error) {
+	img, _, err := ebitenutil.NewImageFromFile(firePath)
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}
+
+// LoadMissImage:
+// - Carrega a imagem para marcar erros (miss) nos tiros
+// - Usada no renderer para desenhar marcadores de jogadas
+func LoadMissImage() (*ebiten.Image, error) {
+	img, _, err := ebitenutil.NewImageFromFile(missPath)
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}

--- a/internal/bootstrap/random.go
+++ b/internal/bootstrap/random.go
@@ -1,0 +1,13 @@
+package bootstrap
+
+import (
+	"math/rand"
+	"time"
+)
+
+// InitRandom inicializa a seed global de rand
+// para toda a aplicação, evitando chamadas repetidas
+// em cada service individual.
+func InitRandom() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/internal/service/ai_fleet_service.go
+++ b/internal/service/ai_fleet_service.go
@@ -1,0 +1,75 @@
+// AIFleetService: posiciona navios da IA em um board lógico.
+// Responsável por:
+// - Resetar o entity.Board
+// - Tentar colocar cada entity.Ship aleatoriamente sem colisões
+// - Definir orientação horizontal/vertical por sorteio
+// É uma peça de domínio da IA (não visual).
+package service
+
+import (
+	"math/rand"
+
+	"github.com/allanjose001/go-battleship/internal/entity"
+)
+
+type AIFleetService struct{}
+
+func NewAIFleetService() *AIFleetService {
+	return &AIFleetService{}
+}
+
+// PositionShipsRandomly:
+// - Limpa o board lógico
+// - Itera sobre a fleet tentando colocar cada navio
+// - Recomeça se algum navio não couber após várias tentativas
+func (s *AIFleetService) PositionShipsRandomly(b *entity.Board, f *entity.Fleet) {
+	for {
+		s.resetBoard(b)
+
+		success := true
+		for _, ship := range f.Ships {
+			if !s.placeRandomShip(b, ship) {
+				success = false
+				break
+			}
+		}
+
+		if success {
+			break
+		}
+	}
+}
+
+// resetBoard: volta todas as posições ao estado inicial
+func (s *AIFleetService) resetBoard(b *entity.Board) {
+	for i := 0; i < entity.BoardSize; i++ {
+		for j := 0; j < entity.BoardSize; j++ {
+			b.Positions[i][j] = entity.Position{}
+		}
+	}
+}
+
+// placeRandomShip: sorteia posição e orientação e tenta colocar o navio
+func (s *AIFleetService) placeRandomShip(b *entity.Board, ship *entity.Ship) bool {
+	if ship == nil {
+		return true
+	}
+
+	for attempts := 0; attempts < 1000; attempts++ {
+		ship.Horizontal = rand.Intn(2) == 0
+
+		var row, col int
+		if ship.Horizontal {
+			row = rand.Intn(entity.BoardSize)
+			col = rand.Intn(entity.BoardSize - ship.Size + 1)
+		} else {
+			row = rand.Intn(entity.BoardSize - ship.Size + 1)
+			col = rand.Intn(entity.BoardSize)
+		}
+
+		if b.PlaceShip(ship, row, col) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/attack_service.go
+++ b/internal/service/attack_service.go
@@ -1,0 +1,81 @@
+// AttackService: concentra a regra de combate.
+// Responsável por aplicar ataques do jogador no board visual da IA
+// e executar o turno da IA sincronizando o entity.Board com o board
+// visual do jogador. Não orquestra turnos (isso é do BattleService).
+package service
+
+import (
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/internal/ai"
+	"github.com/allanjose001/go-battleship/internal/entity"
+)
+
+type AttackService struct{}
+
+func NewAttackService() *AttackService {
+	return &AttackService{}
+}
+
+// PlayerAttack:
+// - Ignora células já atacadas
+// - Conta tentativa
+// - Marca Hit/Miss conforme estado da célula
+// - Retorna indicadores de acerto e fim de jogo usando totalShipCells
+func (s *AttackService) PlayerAttack(aiBoard *board.Board, row, col int, attempts, hits, totalShipCells int) (int, int, bool, bool) {
+	cell := &aiBoard.Cells[row][col]
+
+	if cell.State == board.Hit || cell.State == board.Miss {
+		return attempts, hits, false, false
+	}
+
+	attempts++
+
+	if cell.State == board.Ship {
+		cell.State = board.Hit
+		hits++
+		if hits >= totalShipCells {
+			return attempts, hits, true, true
+		}
+		return attempts, hits, true, false
+	}
+
+	if cell.State == board.Empty {
+		cell.State = board.Miss
+	}
+
+	return attempts, hits, false, false
+}
+
+// AITurn:
+// - Pede para o AIPlayer atacar o entity.Board do jogador
+// - Sincroniza esse ataque com o board visual (marcando Hit/Miss)
+// - Checa fim de jogo com totalShipCells
+func (s *AttackService) AITurn(aiPlayer *ai.AIPlayer, entityBoard *entity.Board, playerBoard *board.Board, attempts, hits, totalShipCells int) (int, int, bool) {
+	if aiPlayer == nil {
+		return attempts, hits, false
+	}
+
+	attempts++
+	aiPlayer.Attack(entityBoard)
+
+	for r := 0; r < board.Rows; r++ {
+		for c := 0; c < board.Cols; c++ {
+			entPos := entityBoard.Positions[r][c]
+			cell := &playerBoard.Cells[r][c]
+
+			if entity.IsAttacked(entPos) && cell.State != board.Hit && cell.State != board.Miss {
+				if cell.State == board.Ship {
+					cell.State = board.Hit
+					hits++
+					if hits >= totalShipCells {
+						return attempts, hits, true
+					}
+				} else {
+					cell.State = board.Miss
+				}
+			}
+		}
+	}
+
+	return attempts, hits, false
+}

--- a/internal/service/battle_service.go
+++ b/internal/service/battle_service.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"time"
+
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/game/shared/placement"
+	"github.com/allanjose001/go-battleship/game/state"
+	"github.com/allanjose001/go-battleship/internal/ai"
+	"github.com/allanjose001/go-battleship/internal/entity"
+)
+
+// BattleService concentra toda a lógica da fase de batalha:
+// controle de turno, cliques do jogador, turno da IA e estatísticas.
+type BattleService struct {
+	// state guarda os tabuleiros e dados globais do jogo
+	state       *state.GameState
+	attack      *AttackService
+	battleSetup *BattleSetupService
+	// aiPlayer é a inteligência artificial que decide os tiros da IA
+	aiPlayer *ai.AIPlayer
+	// entityBoard e entityFleet representam a visão interna da IA
+	entityBoard *entity.Board
+	entityFleet *entity.Fleet
+
+	playerShips []*placement.ShipPlacement
+
+	totalShipCells int
+
+	// contadores de tentativas e acertos do jogador e da IA
+	playerAttempts int
+	playerHits     int
+	aiAttempts     int
+	aiHits         int
+
+	// indica de quem é o turno atual
+	isPlayerTurn bool
+
+	// controle de atraso entre o tiro do jogador e o da IA
+	aiTurnPending bool
+	aiTurnAt      time.Time
+
+	// vencedor atual ("", "Jogador 1" ou "Jogador 2")
+	winner string
+}
+
+// NewBattleService cria um serviço de batalha baseado em um GameState já existente.
+// Se o GameService não for passado, é criada uma instância padrão.
+func NewBattleService(gs *state.GameState, game *GameService, playerShips []*placement.ShipPlacement) *BattleService {
+	b := &BattleService{
+		state:        gs,
+		playerShips:  playerShips,
+		attack:       NewAttackService(),
+		battleSetup:  NewBattleSetupService(),
+		isPlayerTurn: true,
+	}
+
+	b.totalShipCells = calculateTotalCells(playerShips)
+
+	b.aiPlayer, b.entityBoard, b.entityFleet = b.battleSetup.InitBattleAI(playerShips)
+
+	return b
+}
+
+// HandlePlayerClick trata o clique do jogador no tabuleiro da IA.
+// Converte a posição do mouse em célula, aplica o ataque e atualiza o turno.
+// Retorna o nome do vencedor (caso a jogada finalize a partida).
+func (b *BattleService) HandlePlayerClick(mouseX, mouseY float64) string {
+	if !b.isPlayerTurn || b.winner != "" {
+		return b.winner
+	}
+
+	aiBoard := b.state.AIBoard
+
+	// Ignora cliques fora da área do tabuleiro da IA
+	if mouseX < aiBoard.X || mouseX > aiBoard.X+aiBoard.Size || mouseY < aiBoard.Y || mouseY > aiBoard.Y+aiBoard.Size {
+		return b.winner
+	}
+
+	// Traduz coordenadas de tela para linha/coluna do tabuleiro
+	cellSize := aiBoard.Size / float64(board.Cols)
+	col := int((mouseX - aiBoard.X) / cellSize)
+	row := int((mouseY - aiBoard.Y) / cellSize)
+
+	if col < 0 || col >= board.Cols || row < 0 || row >= board.Rows {
+		return b.winner
+	}
+
+	var gameOver bool
+
+	b.playerAttempts, b.playerHits, _, gameOver = b.attack.PlayerAttack(aiBoard, row, col, b.playerAttempts, b.playerHits, b.totalShipCells)
+
+	if gameOver {
+		b.winner = "Jogador 1"
+		return b.winner
+	}
+
+	// Passa o turno para a IA com um pequeno atraso visual
+	b.isPlayerTurn = false
+	b.aiTurnPending = true
+	b.aiTurnAt = time.Now().Add(500 * time.Millisecond)
+
+	return b.winner
+}
+
+// Update processa o turno da IA quando for a vez dela jogar.
+// Também verifica se a partida terminou.
+func (b *BattleService) Update() string {
+	if b.winner != "" {
+		return b.winner
+	}
+
+	if b.aiTurnPending && time.Now().After(b.aiTurnAt) {
+		b.aiTurnPending = false
+
+		// Se algo falhar na inicialização da IA, devolve o turno ao jogador
+		if b.aiPlayer == nil || b.entityBoard == nil {
+			b.isPlayerTurn = true
+			return b.winner
+		}
+
+		var gameOver bool
+
+		b.aiAttempts, b.aiHits, gameOver = b.attack.AITurn(b.aiPlayer, b.entityBoard, b.state.PlayerBoard, b.aiAttempts, b.aiHits, b.totalShipCells)
+
+		if gameOver {
+			b.winner = "Jogador 2"
+			return b.winner
+		}
+
+		// Terminado o turno da IA, devolve o turno ao jogador
+		b.isPlayerTurn = true
+	}
+
+	return b.winner
+}
+
+// Stats retorna estatísticas básicas da partida e se é turno do jogador.
+func (b *BattleService) Stats() (int, int, int, int, bool) {
+	return b.playerAttempts, b.playerHits, b.aiAttempts, b.aiHits, b.isPlayerTurn
+}
+
+// PlayerBoard retorna o tabuleiro do jogador.
+func (b *BattleService) PlayerBoard() *board.Board {
+	return b.state.PlayerBoard
+}
+
+// AIBoard retorna o tabuleiro da IA.
+func (b *BattleService) AIBoard() *board.Board {
+	return b.state.AIBoard
+}
+
+func (b *BattleService) PlayerShips() []*placement.ShipPlacement {
+	return b.playerShips
+}
+func calculateTotalCells(ships []*placement.ShipPlacement) int {
+	total := 0
+	for _, s := range ships {
+		if s != nil {
+			total += s.Size
+		}
+	}
+	return total
+}

--- a/internal/service/battle_setup_service.go
+++ b/internal/service/battle_setup_service.go
@@ -1,0 +1,56 @@
+// BattleSetupService: inicializa as estruturas que a IA usa na batalha.
+// Responsável por:
+// - Criar a Fleet (entidade lógica de navios) usada pela IA
+// - Mapear placements visuais do jogador (board.Board + ShipPlacement)
+//   para a representação lógica (entity.Board + entity.Ship)
+// - Instanciar o AIPlayer com a fleet resultante
+package service
+
+import (
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/game/shared/placement"
+	"github.com/allanjose001/go-battleship/internal/ai"
+	"github.com/allanjose001/go-battleship/internal/entity"
+)
+
+type BattleSetupService struct{}
+
+func NewBattleSetupService() *BattleSetupService {
+	return &BattleSetupService{}
+}
+
+// InitBattleAI:
+// - Varre os navios posicionados pelo jogador e procura correspondentes na Fleet
+// - Respeita orientação e posição (X/Y) ao colocar no entity.Board
+// - Cria um AIPlayer “hard” com estratégias combinadas
+// - Retorna o AIPlayer, o board lógico e a fleet que ele rastreia
+func (s *BattleSetupService) InitBattleAI(playerShips []*placement.ShipPlacement) (*ai.AIPlayer, *entity.Board, *entity.Fleet) {
+	fleet := entity.NewFleet()
+	entityBoard := &entity.Board{}
+
+	usedShips := make(map[int]bool)
+
+	for _, ps := range playerShips {
+		if !ps.Placed {
+			continue
+		}
+
+		var entShip *entity.Ship
+		for i, ship := range fleet.Ships {
+			if !usedShips[i] && ship.Size == ps.Size {
+				entShip = ship
+				usedShips[i] = true
+				break
+			}
+		}
+
+		if entShip != nil {
+			entShip.Horizontal = ps.Orientation == board.Horizontal
+			entityBoard.PlaceShip(entShip, ps.Y, ps.X)
+		}
+	}
+
+	aiPlayer := ai.NewHardAIPlayer(fleet)
+
+	return aiPlayer, entityBoard, fleet
+}

--- a/internal/service/game_state_factory.go
+++ b/internal/service/game_state_factory.go
@@ -1,0 +1,36 @@
+// GameStateFactory: cria o estado de batalha (GameState) a partir
+// do tabuleiro já configurado do jogador e da lista de navios
+// posicionados. Não conhece regras de ataque nem IA; foca apenas
+// em construir a estrutura de dados usada pela fase de batalha.
+package service
+
+import (
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/game/shared/placement"
+	"github.com/allanjose001/go-battleship/game/shared/setup"
+	"github.com/allanjose001/go-battleship/game/state"
+)
+
+type GameService struct{}
+
+func NewGameService() *GameService {
+	return &GameService{}
+}
+
+// NewBattleGameState:
+// - Reaproveita o board do jogador e clona as dimensões para o board da IA
+// - Posiciona os navios da IA no tabuleiro dela (visual) via setup
+// - Devolve um GameState pronto para a BattleScene consumir
+func (g *GameService) NewBattleGameState(playerBoard *board.Board, ships []*placement.ShipPlacement) *state.GameState {
+	gs := state.NewGameState()
+	gs.PlayerBoard = playerBoard
+	gs.PlayerShips = ships
+
+	gs.AIBoard.X = 1280 - playerBoard.X - playerBoard.Size
+	gs.AIBoard.Y = playerBoard.Y
+	gs.AIBoard.Size = playerBoard.Size
+
+	setup.RandomlyPlaceAIShips(gs.AIBoard)
+
+	return gs
+}

--- a/internal/service/placement.go
+++ b/internal/service/placement.go
@@ -1,52 +1,287 @@
 package service
 
 import (
-    "github.com/allanjose001/go-battleship/internal/entity"
-    "math/rand"
-    "time"
-    "fmt"
+	"math"
+	"math/rand"
+
+	"github.com/allanjose001/go-battleship/game/shared/board"
+	"github.com/allanjose001/go-battleship/game/shared/placement"
 )
 
-func PositionShipsRandomly(b *entity.Board, f *entity.Fleet) {
-    rand.Seed(time.Now().UnixNano())
+// PlacementRenderer descreve qualquer tipo capaz de desenhar o tabuleiro
+// de posicionamento e os navios, usado pela cena de placement.
+type PlacementRenderer interface {
+	Draw(b *board.Board, ships []*placement.ShipPlacement, active *placement.ShipPlacement, orientation board.Orientation)
+}
 
-restart:
-    // limpa tabuleiro
-    for i := 0; i < entity.BoardSize; i++ {
-        for j := 0; j < entity.BoardSize; j++ {
-            b.Positions[i][j] = entity.Position{}
-        }
-    }
+// PlacementService define as operações de alto nível usadas pela cena
+// de placement para manipular navios.
+type PlacementService interface {
+	AllShipsPlaced() bool
+	RandomPlacement()
+	Rotate()
+	SelectOnBoard(mouseX, mouseY float64) bool
+	SelectOnList(mouseX, mouseY float64) bool
+	UpdateDragging(mouseX, mouseY float64)
+	DropSelected() bool
+	Draw(r PlacementRenderer)
+	BoardRect() (x, y, size float64)
+}
 
-    for _, ship := range f.Ships {
-        if ship == nil {
-            continue
-        }
+// placementService é a implementação concreta de PlacementService.
+// Ela guarda o tabuleiro, a lista de navios e o estado de seleção/drag.
+type placementService struct {
+	board       *board.Board
+	ships       []*placement.ShipPlacement
+	selected    *placement.ShipPlacement
+	activeShip  *placement.ShipPlacement
+	orientation board.Orientation
+}
 
-        placed := false
-        attempts := 0
-        for !placed && attempts < 1000 {
-            attempts++
-            ship.Horizontal = rand.Intn(2) == 0
+// NewPlacementService cria um novo serviço de posicionamento com
+// orientação inicial horizontal.
+func NewPlacementService(b *board.Board, ships []*placement.ShipPlacement) PlacementService {
+	return &placementService{
+		board:       b,
+		ships:       ships,
+		orientation: board.Horizontal,
+	}
+}
 
-            var row, col int
-            if ship.Horizontal {
-                row = rand.Intn(entity.BoardSize)
-                col = rand.Intn(entity.BoardSize - ship.Size + 1)
-            } else {
-                row = rand.Intn(entity.BoardSize - ship.Size + 1)
-                col = rand.Intn(entity.BoardSize)
-            }
+// AllShipsPlaced retorna true quando todos os navios já foram
+// posicionados no tabuleiro visual.
+func (p *placementService) AllShipsPlaced() bool {
+	for _, ship := range p.ships {
+		if !ship.Placed {
+			return false
+		}
+	}
+	return true
+}
 
-            if b.PlaceShip(ship, row, col) {
-                placed = true
-                fmt.Printf("Navio %s posicionado em %v,%v (Horizontal: %v)\n", ship.Name, row, col, ship.Horizontal)
-            }
-        }
+// RandomPlacement limpa o tabuleiro visual e reposiciona todos os navios
+// aleatoriamente, atualizando também os metadados de cada ShipPlacement.
+func (p *placementService) RandomPlacement() {
+	p.board.Clear()
 
-        // se falhar em posicionar um navio depois de muitas tentativas, reinicia todo o processo
-        if !placed {
-            goto restart
-        }
-    }
+	for _, ship := range p.ships {
+		ship.Placed = false
+	}
+
+	var lastPlaced *placement.ShipPlacement
+
+	for _, ship := range p.ships {
+		for {
+			row := rand.Intn(board.Rows)
+			col := rand.Intn(board.Cols)
+			or := board.Orientation(rand.Intn(2))
+
+			if p.board.CanPlace(ship.Size, row, col, or) {
+				p.board.PlaceShip(ship.Size, row, col, or)
+				ship.Placed = true
+				ship.X = col
+				ship.Y = row
+				ship.Orientation = or
+				lastPlaced = ship
+				break
+			}
+		}
+	}
+
+	p.activeShip = lastPlaced
+}
+
+// DropSelected tenta soltar o navio selecionado no tabuleiro,
+// convertendo a posição do drag em linha/coluna. Retorna true em caso de sucesso.
+func (p *placementService) DropSelected() bool {
+	if p.selected == nil {
+		return false
+	}
+
+	ship := p.selected
+	ship.Dragging = false
+
+	cellSize := p.board.Size / float64(board.Cols)
+
+	targetX := ship.DragX
+	targetY := ship.DragY
+
+	// Verifica se a área do navio arrastado intersecta o tabuleiro
+	if targetX+cellSize*float64(ship.Size) > p.board.X && targetX < p.board.X+p.board.Size &&
+		targetY+cellSize*float64(ship.Size) > p.board.Y && targetY < p.board.Y+p.board.Size {
+
+		// Converte a posição de drag para índices de célula
+		col := int(math.Round((targetX - p.board.X) / cellSize))
+		row := int(math.Round((targetY - p.board.Y) / cellSize))
+
+		if p.board.CanPlace(ship.Size, row, col, p.orientation) {
+			p.board.PlaceShip(ship.Size, row, col, p.orientation)
+			ship.Placed = true
+			ship.X = col
+			ship.Y = row
+			ship.Orientation = p.orientation
+			p.activeShip = ship
+			return true
+		}
+	}
+
+	// Se não conseguir colocar, o navio volta para a lista
+	ship.Placed = false
+	return false
+}
+
+// removeShipFromBoard limpa o tabuleiro e recoloca todos os navios
+// exceto o alvo, usado principalmente durante a rotação.
+func (p *placementService) removeShipFromBoard(target *placement.ShipPlacement) {
+	if target == nil {
+		return
+	}
+
+	target.Placed = false
+	p.board.Clear()
+
+	for _, ship := range p.ships {
+		if ship != target && ship.Placed {
+			p.board.PlaceShip(ship.Size, ship.Y, ship.X, ship.Orientation)
+		}
+	}
+}
+
+// Rotate rotaciona o navio ativo no tabuleiro, se existir,
+// ou apenas alterna a orientação padrão dos próximos navios.
+func (p *placementService) Rotate() {
+	if p.activeShip != nil && p.activeShip.Placed {
+		p.rotateActive()
+	} else {
+		p.toggleOrientation()
+	}
+}
+
+// rotateActive tenta rotacionar o navio ativo mantendo a posição de origem.
+// Caso não seja possível, restaura a orientação anterior.
+func (p *placementService) rotateActive() bool {
+	ship := p.activeShip
+	if ship == nil || !ship.Placed {
+		return false
+	}
+
+	newOri := board.Horizontal
+	if ship.Orientation == board.Horizontal {
+		newOri = board.Vertical
+	}
+
+	if ship.Orientation == newOri {
+		return true
+	}
+
+	p.removeShipFromBoard(ship)
+
+	if p.board.CanPlace(ship.Size, ship.Y, ship.X, newOri) {
+		p.board.PlaceShip(ship.Size, ship.Y, ship.X, newOri)
+		ship.Orientation = newOri
+		ship.Placed = true
+		p.orientation = newOri
+		return true
+	}
+
+	p.board.PlaceShip(ship.Size, ship.Y, ship.X, ship.Orientation)
+	ship.Placed = true
+	return false
+}
+
+// toggleOrientation alterna a orientação padrão usada para novos placements.
+func (p *placementService) toggleOrientation() {
+	if p.orientation == board.Horizontal {
+		p.orientation = board.Vertical
+	} else {
+		p.orientation = board.Horizontal
+	}
+}
+
+// SelectOnBoard tenta selecionar um navio já colocado no tabuleiro
+// para iniciar um drag a partir da posição real dele.
+func (p *placementService) SelectOnBoard(mouseX, mouseY float64) bool {
+	for _, ship := range p.ships {
+		if !ship.Placed {
+			continue
+		}
+
+		cellSize := p.board.Size / float64(board.Cols)
+		x := p.board.X + float64(ship.X)*cellSize
+		y := p.board.Y + float64(ship.Y)*cellSize
+
+		w := cellSize * float64(ship.Size)
+		h := cellSize
+		if ship.Orientation == board.Vertical {
+			w, h = h, w
+		}
+
+		// Verifica se o clique caiu dentro da área ocupada pelo navio
+		if mouseX >= x && mouseX <= x+w && mouseY >= y && mouseY <= y+h {
+			ship.Dragging = true
+			ship.DragX = x
+			ship.DragY = y
+			ship.OffsetX = mouseX - x
+			ship.OffsetY = mouseY - y
+			p.selected = ship
+			p.activeShip = ship
+			p.orientation = ship.Orientation
+			return true
+		}
+	}
+
+	return false
+}
+
+// SelectOnList tenta selecionar um navio ainda não colocado na lista
+// lateral, iniciando um drag a partir da posição fixa da lista.
+func (p *placementService) SelectOnList(mouseX, mouseY float64) bool {
+	for _, ship := range p.ships {
+		if ship.Placed {
+			continue
+		}
+
+		w, h := ship.Image.Size()
+
+		if mouseX >= ship.ListX && mouseX <= ship.ListX+float64(w) &&
+			mouseY >= ship.ListY && mouseY <= ship.ListY+float64(h) {
+
+			ship.Dragging = true
+			ship.DragX = ship.ListX
+			ship.DragY = ship.ListY
+			ship.OffsetX = mouseX - ship.ListX
+			ship.OffsetY = mouseY - ship.ListY
+			p.selected = ship
+			p.activeShip = ship
+			return true
+		}
+	}
+
+	return false
+}
+
+// UpdateDragging atualiza a posição de drag do navio selecionado
+// com base na posição atual do mouse.
+func (p *placementService) UpdateDragging(mouseX, mouseY float64) {
+	ship := p.selected
+	if ship == nil || !ship.Dragging {
+		return
+	}
+
+	ship.DragX = mouseX - ship.OffsetX
+	ship.DragY = mouseY - ship.OffsetY
+}
+
+// Draw delega o desenho do tabuleiro e navios para o renderer injetado.
+func (p *placementService) Draw(r PlacementRenderer) {
+	if r == nil {
+		return
+	}
+	r.Draw(p.board, p.ships, p.activeShip, p.orientation)
+}
+
+// BoardRect retorna a posição e o tamanho do tabuleiro,
+// útil para alinhar elementos visuais na cena.
+func (p *placementService) BoardRect() (x, y, size float64) {
+	return p.board.X, p.board.Y, p.board.Size
 }


### PR DESCRIPTION
refatora fluxo de batalha e posicionamento

- Isola PlacementService como serviço puro de posicionamento visual do jogador
- Cria GameService para montar GameState de batalha a partir do board do jogador
- Adiciona BattleSetupService para montar board lógico e fleet usados pela IA
- Extrai regras de combate para AttackService (ataque do jogador e turno da IA)
- Centraliza orquestração de batalha em BattleService (turnos, atrasos, estatísticas)
- Mantém AIFleetService para randomização de frota lógica da IA em entity.Board
- Move renderização da batalha para BattleScene, incluindo HUD e efeitos de Hit/Miss
- Centraliza carregamento de GIFs e imagens de batalha em assets/loader.go